### PR TITLE
Fixing tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>8.26</version>
+                        <version>8.29</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <storm.version>2.1.0</storm.version>
         <storm.metrics.version>2.1.0</storm.metrics.version>
         <jackson.core.version>2.10.2</jackson.core.version>
-        <bullet.core.version>1.0.0</bullet.core.version>
+        <bullet.core.version>1.1.0</bullet.core.version>
         <bullet.dsl.version>1.0.0</bullet.dsl.version>
     </properties>
 

--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -161,9 +161,6 @@
             <property name="severity" value="error"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
-            <property name="allowUndeclaredRTE" value="true"/>
         </module>
 
         <!-- Checks that variables have Javadoc comments. -->

--- a/src/test/resources/test_dsl_config.yaml
+++ b/src/test/resources/test_dsl_config.yaml
@@ -8,6 +8,7 @@ bullet.dsl.connector.async.commit.enable: true
 # The classpath to the BulletRecordConverter to use
 bullet.dsl.converter.class.name: "com.yahoo.bullet.dsl.converter.MapBulletRecordConverter"
 bullet.dsl.converter.schema.file: "test_dsl_schema.json"
+bullet.dsl.converter.schema.type.check.enable: true
 
 # The classpath to the BulletDeserializer to use
 bullet.dsl.deserializer.class.name: "com.yahoo.bullet.storm.testing.MockDeserializer"


### PR DESCRIPTION
Cannot go to Storm 2.2 for the v2 metrics tick yet because https://issues.apache.org/jira/browse/STORM-3663 is only in Storm 2.2.1 + and it's not released yet.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
